### PR TITLE
Start TCP listener only when all plugins are initialized.

### DIFF
--- a/PropertyServer.Plugin/PropertyServer/PropertyServerPlugin.cs
+++ b/PropertyServer.Plugin/PropertyServer/PropertyServerPlugin.cs
@@ -23,7 +23,7 @@ namespace SimHub.Plugins.PropertyServer
     [PluginName("Property Server")]
     [PluginAuthor("Martin Renner")]
     [PluginDescription("Provides a network server for read access to game properties - v" + ThisAssembly.AssemblyFileVersion)]
-    public class PropertyServerPlugin : IDataPlugin, IWPFSettingsV2, ISimHub, IInputPlugin
+    public class PropertyServerPlugin : IDataPlugin, IPluginV2, IWPFSettingsV2, IInputPlugin, ISimHub
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(PropertyServerPlugin));
         private GeneralSettings _settings = new GeneralSettings();
@@ -66,7 +66,11 @@ namespace SimHub.Plugins.PropertyServer
             // Move execution of server into a new task/thread (away from SimHub thread). The server is async, but we
             // do not want to put any unnecessary load onto the SimHub thread.
             _server = new Server(this, _subscriptionManager, _settings.Port);
-            Task.Run(_server.Start);
+        }
+
+        public void PluginManagerLoaded(PluginManager pluginManager)
+        {
+            _ = Task.Run(_server.Start);
         }
 
         public void End(PluginManager pluginManager)
@@ -87,30 +91,29 @@ namespace SimHub.Plugins.PropertyServer
             const long updateMillis = 100;
 
             var now = DateTime.Now.Ticks / TimeSpan.TicksPerMillisecond;
-            if (now - _lastDataUpdate > updateMillis)
+            if (now - _lastDataUpdate < updateMillis) return;
+
+            try
             {
-                try
+                DataUpdateInternal(data);
+            }
+            catch (Exception e)
+            {
+                // We are on the critical path of the SimHub thread. Writing excessive logs does not help and is I/O intensive.
+                // So we stop reporting unhandled exceptions after a specific limit.
+                if (_unhandledExceptionCount < 50)
                 {
-                    DataUpdateInternal(data);
-                }
-                catch (Exception e)
-                {
-                    // We are on the critical path of the SimHub thread. Writing excessive logs does not help and is I/O intensive.
-                    // So we stop reporting unhandled exceptions after a specific limit.
-                    if (_unhandledExceptionCount < 50)
+                    _unhandledExceptionCount++;
+                    Log.Error($"Oh no, we have an unhandled exception: {e}");
+                    if (_unhandledExceptionCount >= 50)
                     {
-                        _unhandledExceptionCount++;
-                        Log.Error($"Oh no, we have an unhandled exception: {e}");
-                        if (_unhandledExceptionCount >= 50)
-                        {
-                            Log.Error($"Reached limit of more than {_unhandledExceptionCount} unhandled exceptions.");
-                            Log.Error("Not reporting any more exceptions, but most probably the problem still exists.");
-                        }
+                        Log.Error($"Reached limit of more than {_unhandledExceptionCount} unhandled exceptions.");
+                        Log.Error("Not reporting any more exceptions, but most probably the problem still exists.");
                     }
                 }
-
-                _lastDataUpdate = now;
             }
+
+            _lastDataUpdate = now;
         }
 
         private async void DataUpdateInternal(GameData data)

--- a/PropertyServer.Plugin/PropertyServer/ShakeIt/ShakeItAccessor.cs
+++ b/PropertyServer.Plugin/PropertyServer/ShakeIt/ShakeItAccessor.cs
@@ -15,14 +15,8 @@ namespace SimHub.Plugins.PropertyServer.ShakeIt
     /// </summary>
     public class ShakeItAccessor
     {
-        private readonly ShakeITBSV3Plugin _shakeItBassPlugin;
-        private readonly ShakeITMotorsV3Plugin _shakeItMotorsPlugin;
-
-        public ShakeItAccessor()
-        {
-            _shakeItBassPlugin = PluginManager.GetInstance().GetPlugin<ShakeITBSV3Plugin>();
-            _shakeItMotorsPlugin = PluginManager.GetInstance().GetPlugin<ShakeITMotorsV3Plugin>();
-        }
+        private readonly ShakeITBSV3Plugin _shakeItBassPlugin = PluginManager.GetInstance().GetPlugin<ShakeITBSV3Plugin>();
+        private readonly ShakeITMotorsV3Plugin _shakeItMotorsPlugin = PluginManager.GetInstance().GetPlugin<ShakeITMotorsV3Plugin>();
 
         /// <summary>
         /// Returns all known profiles of the given plugin, which must be a "ShakeItV3" plugin.
@@ -33,7 +27,7 @@ namespace SimHub.Plugins.PropertyServer.ShakeIt
         private IEnumerable<ShakeItProfile> SimHubProfiles<T, TSettingsType>(ShakeITV3PluginBase<T, TSettingsType> shakeItPlugin)
             where T : IOutputManager where TSettingsType : ShakeItSettings<T>, new()
         {
-            return shakeItPlugin == null ? Enumerable.Empty<ShakeItProfile>() : shakeItPlugin.Settings.Profiles;
+            return shakeItPlugin?.Settings == null ? Enumerable.Empty<ShakeItProfile>() : shakeItPlugin.Settings.Profiles;
         }
 
         /// <summary>


### PR DESCRIPTION
This is to avoid race conditions, when accessing the ShakeIt plugins after a "subscribe", although these plugins are not yet initialized.

Closes #57