### PR TITLE
Fix reconnect memory leak: serialize writes and make Disconnect idempotent

### DIFF
--- a/PropertyServer.Plugin/PropertyServer/Comm/Client.cs
+++ b/PropertyServer.Plugin/PropertyServer/Comm/Client.cs
@@ -27,6 +27,13 @@ namespace SimHub.Plugins.PropertyServer.Comm
         private long _running;
         private StreamWriter _writer;
         private long _lastSentTicks;
+        // Serializes all writes to _writer. SendString is invoked concurrently from the
+        // per-property ValueChanged callbacks (SimHub data thread) and from PingLoopAsync;
+        // without this lock the overlapping StreamWriter.WriteAsync calls throw
+        // "The stream is currently in use by a previous operation" and force a disconnect.
+        private readonly SemaphoreSlim _writeLock = new SemaphoreSlim(1, 1);
+        // Ensures Disconnect() tears down exactly once (it can be triggered concurrently).
+        private long _disconnected;
 
         /// <summary>Ping interval: send a ping if no message has been sent for this duration.</summary>
         private static readonly TimeSpan PingInterval = TimeSpan.FromSeconds(30);
@@ -303,6 +310,10 @@ namespace SimHub.Plugins.PropertyServer.Comm
 
         private async Task ValueChanged(ValueChangedEventArgs e)
         {
+            // Already disconnecting: don't touch the (closing) stream. Sending here would just
+            // throw and re-enter Disconnect, and doing work for a dead client is pointless.
+            if (!Running) return;
+
             var valueToSend = e.Property.ValueAsString;
             if (e.Property.RawType == typeof(string))
             {
@@ -319,11 +330,23 @@ namespace SimHub.Plugins.PropertyServer.Comm
 
         public async Task Disconnect()
         {
+            // Run the teardown exactly once. Disconnect can be triggered concurrently from
+            // several paths (the read loop ending, a failed SendString on the SimHub data
+            // thread, or an explicit 'disconnect' command). If the unsubscribe loop runs more
+            // than once or re-enters while _mySubscriptions is being mutated, it can abort
+            // partway and leave a ValueChanged handler registered on a shared property. That
+            // dangling delegate roots this whole (dead) Client and keeps firing on every
+            // SimHub update -> a per-connection memory leak that accumulates across reconnects.
+            if (Interlocked.Exchange(ref _disconnected, 1) == 1) return;
             Running = false;
-            foreach (var mySubscription in _mySubscriptions)
+
+            // Iterate a snapshot: Unsubscribe is async and other paths may still touch
+            // _mySubscriptions, so copy first to guarantee every subscription is removed.
+            foreach (var mySubscription in _mySubscriptions.ToList())
             {
                 await _subscriptionManager.Unsubscribe(mySubscription, ValueChanged);
             }
+            _mySubscriptions.Clear();
 
             _tcpClient.Close();
         }
@@ -335,6 +358,11 @@ namespace SimHub.Plugins.PropertyServer.Comm
 
         private async Task SendString(string msg)
         {
+            var writeFailed = false;
+            // Serialize writes so concurrent callers (ValueChanged on the SimHub data thread
+            // and PingLoopAsync) can't overlap on the shared StreamWriter, which otherwise
+            // throws "The stream is currently in use by a previous operation".
+            await _writeLock.WaitAsync();
             try
             {
                 await _writer.WriteAsync($"{msg}\r\n");
@@ -344,8 +372,16 @@ namespace SimHub.Plugins.PropertyServer.Comm
             catch (Exception ex)
             {
                 Log.Warn("Exception while sending data to client. We will disconnect the client.", ex);
-                await Disconnect();
+                writeFailed = true;
             }
+            finally
+            {
+                _writeLock.Release();
+            }
+
+            // Disconnect outside the write lock (Disconnect does not write, but keep the lock
+            // hold time minimal and avoid any chance of re-entrancy).
+            if (writeFailed) await Disconnect();
         }
     }
 }

--- a/PropertyServer.Plugin/PropertyServer/Comm/Client.cs
+++ b/PropertyServer.Plugin/PropertyServer/Comm/Client.cs
@@ -23,17 +23,13 @@ namespace SimHub.Plugins.PropertyServer.Comm
         private readonly ISimHub _simHub;
         private readonly SubscriptionManager _subscriptionManager;
         private readonly HashSet<string> _mySubscriptions = new HashSet<string>();
+        private readonly object _mySubscriptionsLock = new object();
+        private readonly SemaphoreSlim _writeLock = new SemaphoreSlim(1, 1);
         private readonly TcpClient _tcpClient;
         private long _running;
+        private long _disconnecting;
         private StreamWriter _writer;
         private long _lastSentTicks;
-        // Serializes all writes to _writer. SendString is invoked concurrently from the
-        // per-property ValueChanged callbacks (SimHub data thread) and from PingLoopAsync;
-        // without this lock the overlapping StreamWriter.WriteAsync calls throw
-        // "The stream is currently in use by a previous operation" and force a disconnect.
-        private readonly SemaphoreSlim _writeLock = new SemaphoreSlim(1, 1);
-        // Ensures Disconnect() tears down exactly once (it can be triggered concurrently).
-        private long _disconnected;
 
         /// <summary>Ping interval: send a ping if no message has been sent for this duration.</summary>
         private static readonly TimeSpan PingInterval = TimeSpan.FromSeconds(30);
@@ -196,7 +192,11 @@ namespace SimHub.Plugins.PropertyServer.Comm
 
         private async Task Subscribe(string propertyName)
         {
-            if (_mySubscriptions.Contains(propertyName)) return;
+            if (!Running) return;
+            lock (_mySubscriptionsLock)
+            {
+                if (_mySubscriptions.Contains(propertyName)) return;
+            }
 
             var property = await _subscriptionManager.Subscribe(propertyName, ValueChanged, SendError);
             // We have to check here (outside the SubscriptionManager) if the ShakeIt Bass element exists.
@@ -212,18 +212,30 @@ namespace SimHub.Plugins.PropertyServer.Comm
 
             if (property != null)
             {
-                _mySubscriptions.Add(propertyName);
+                lock (_mySubscriptionsLock)
+                {
+                    if (Running)
+                    {
+                        _mySubscriptions.Add(propertyName);
+                    }
+                }
             }
         }
 
         private async Task Unsubscribe(string propertyName)
         {
-            if (!_mySubscriptions.Contains(propertyName)) return;
+            lock (_mySubscriptionsLock)
+            {
+                if (!_mySubscriptions.Contains(propertyName)) return;
+            }
 
             var result = await _subscriptionManager.Unsubscribe(propertyName, ValueChanged);
             if (result)
             {
-                _mySubscriptions.Remove(propertyName);
+                lock (_mySubscriptionsLock)
+                {
+                    _mySubscriptions.Remove(propertyName);
+                }
             }
         }
 
@@ -330,23 +342,30 @@ namespace SimHub.Plugins.PropertyServer.Comm
 
         public async Task Disconnect()
         {
-            // Run the teardown exactly once. Disconnect can be triggered concurrently from
-            // several paths (the read loop ending, a failed SendString on the SimHub data
-            // thread, or an explicit 'disconnect' command). If the unsubscribe loop runs more
-            // than once or re-enters while _mySubscriptions is being mutated, it can abort
-            // partway and leave a ValueChanged handler registered on a shared property. That
-            // dangling delegate roots this whole (dead) Client and keeps firing on every
-            // SimHub update -> a per-connection memory leak that accumulates across reconnects.
-            if (Interlocked.Exchange(ref _disconnected, 1) == 1) return;
+            // Run the teardown exactly once. Disconnect can be triggered concurrently from several paths.
+            if (Interlocked.Exchange(ref _disconnecting, 1) == 1) return;
             Running = false;
 
             // Iterate a snapshot: Unsubscribe is async and other paths may still touch
             // _mySubscriptions, so copy first to guarantee every subscription is removed.
-            foreach (var mySubscription in _mySubscriptions.ToList())
+            List<string> mySubscriptionsSnapshot;
+            lock (_mySubscriptionsLock)
             {
-                await _subscriptionManager.Unsubscribe(mySubscription, ValueChanged);
+                mySubscriptionsSnapshot = _mySubscriptions.ToList();
+                _mySubscriptions.Clear();
             }
-            _mySubscriptions.Clear();
+
+            foreach (var mySubscription in mySubscriptionsSnapshot)
+            {
+                try
+                {
+                    await _subscriptionManager.Unsubscribe(mySubscription, ValueChanged);
+                }
+                catch (Exception e)
+                {
+                    Log.Warn($"Exception while unsubscribing from {mySubscription} during disconnect", e);
+                }
+            }
 
             _tcpClient.Close();
         }
@@ -358,30 +377,30 @@ namespace SimHub.Plugins.PropertyServer.Comm
 
         private async Task SendString(string msg)
         {
-            var writeFailed = false;
-            // Serialize writes so concurrent callers (ValueChanged on the SimHub data thread
-            // and PingLoopAsync) can't overlap on the shared StreamWriter, which otherwise
+            if (!Running) return;
+
+            // Serialize writes so concurrent callers can't overlap on the shared StreamWriter, which otherwise
             // throws "The stream is currently in use by a previous operation".
-            await _writeLock.WaitAsync();
             try
             {
-                await _writer.WriteAsync($"{msg}\r\n");
-                await _writer.FlushAsync();
+                await _writeLock.WaitAsync();
+                try
+                {
+                    await _writer.WriteAsync($"{msg}\r\n");
+                    await _writer.FlushAsync();
+                }
+                finally
+                {
+                    _writeLock.Release();
+                }
+
                 Interlocked.Exchange(ref _lastSentTicks, DateTime.UtcNow.Ticks);
             }
             catch (Exception ex)
             {
                 Log.Warn("Exception while sending data to client. We will disconnect the client.", ex);
-                writeFailed = true;
+                await Disconnect();
             }
-            finally
-            {
-                _writeLock.Release();
-            }
-
-            // Disconnect outside the write lock (Disconnect does not write, but keep the lock
-            // hold time minimal and avoid any chance of re-entrancy).
-            if (writeFailed) await Disconnect();
         }
     }
 }


### PR DESCRIPTION
Under a client that reconnects and re-subscribes repeatedly (e.g. a slow link that gets force-disconnected), the plugin leaks per-connection resources on a 32-bit SimHub until it throws `OutOfMemoryException`. I traced it to two coupled issues in `Comm/Client.cs`:

**1. Unsynchronized writes to the shared `StreamWriter`.** `SendString` writes `_writer` with no serialization while it is called concurrently from `ValueChanged` (the SimHub data thread, once per changed value, not awaited) and from `PingLoopAsync`. When two writes overlap, `StreamWriter` throws *"The stream is currently in use by a previous operation"*; the `catch` then force-disconnects the client. Auto-reconnecting clients re-subscribe and the cycle repeats.

**2. `Disconnect()` is neither idempotent nor serialized.** It iterates the plain `HashSet _mySubscriptions` while a concurrent `ValueChanged -> SendString -> Disconnect` re-entry mutates the same set. The unsubscribe loop can abort part-way and leave a `ValueChanged` handler still registered on a shared property. That dangling delegate roots the whole dead `Client` (its stream buffers, `TcpClient`, socket, ping task) **and** keeps firing on every telemetry tick, so memory grows across reconnects even after every client has disconnected.

On a 32-bit (LargeAddressAware) SimHub this reached ~1.1 GB/hr under reconnect churn and OOM-crashed in ~3.5 h.

### Changes
- Serialize all `_writer` writes behind a `SemaphoreSlim(1,1)` in `SendString` (removes the race -> no more forced disconnects -> no churn).
- Make `Disconnect()` run exactly once (`Interlocked` guard) and iterate a snapshot of `_mySubscriptions` so every `ValueChanged` handler is always unsubscribed.
- Return early from `ValueChanged` when the client is no longer `Running`.

### Testing
Built against 1.16.13 and tested on a 32-bit SimHub with a reconnect-churn reproducer (1,357 connect->subscribe->disconnect cycles, 66,493 subscribes total):

| Phase | Condition | Before | After |
|---|---|---|---|
| Fresh, no client | baseline | flat | flat |
| Reconnect churn | 66,493 subs | **+1,380 MB/hr** | **flat (GC-reclaimed)** |
| Churn stopped, no client | — | **+1,140 MB/hr (leak persists)** | **flat** |

Zero *"stream is currently in use"* errors and zero forced disconnects across the whole run, and the self-sustaining post-churn leak is gone.

### Related issues
- **#70** reports the same server-side symptom from a different client: the exact `SendString` exception *"The stream is currently in use by a previous operation on the stream"* followed by *"We will disconnect the client"* (reported by @matey3cush, independently confirmed by @KKriz with `netstat` evidence and the game start/stop update burst as the trigger). This PR removes that race at the source.
- **#33** is an earlier, related client-side reconnect symptom.
- Complements the merged heartbeat (#72): the heartbeat lets the *client* detect a dead connection and reconnect, but it does not remove the server-side write race — it actually adds a second concurrent writer via the periodic `ping`. This change is stacked on top of the heartbeat and closes that gap on the server side.